### PR TITLE
oparl: replace organizationType with classification

### DIFF
--- a/app/api/oparl/entities/organization.rb
+++ b/app/api/oparl/entities/organization.rb
@@ -8,7 +8,7 @@ module OParl
 
       with_options(unless: lambda { |obj, _| obj.deleted? }) do
         expose :name
-        expose(:organizationType) { |org| org.is_a?(::Ministry) ? 'Ministerium' : 'Fraktion' } # TODO: add type to model
+        expose(:classification) { |org| org.is_a?(::Ministry) ? 'Ministerium' : 'Fraktion' } # TODO: add type to model
 
         expose(:web) do |org, options| # equivalent in html
           if org.is_a?(::Ministry)


### PR DESCRIPTION
"Ministerium" is not a valid value for `organizationType`, so I've replaced it with the appropriate field, `classification`.

Admittedly I haven't tested it yet as the oparl api didn't want to work locally, but I doubt that I've broken something.