### PR TITLE
update privacy policy info page

### DIFF
--- a/app/views/info/datenschutz.html.erb
+++ b/app/views/info/datenschutz.html.erb
@@ -2,4 +2,84 @@
 
 <h1>Datenschutz</h1>
 
-<a href="https://www.iubenda.com/privacy-policy/362490" class="iubenda-white no-brand iub-body-embed iubenda-embed" title="Datenschutzerklärung">Datenschutzerklärung</a><script type="text/javascript">(function (w,d) {var loader = function () {var s = d.createElement("script"), tag = d.getElementsByTagName("script")[0]; s.src = "//cdn.iubenda.com/iubenda.js"; tag.parentNode.insertBefore(s,tag);}; if(w.addEventListener){w.addEventListener("load", loader, false);}else if(w.attachEvent){w.attachEvent("onload", loader);}else{w.onload = loader;}})(window, document);</script>
+<p>Wie wir mit Ihren personenbezogenen Daten umgehen, erläutern wir Ihnen in dieser Datenschutzerklärung. Maßgabe ist das geltende Datenschutzrecht, insbesondere die Datenschutz-Grundverordnung (DSGVO). Mit Ausnahme der Dienstleister und Drittanbieter, die wir in dieser Datenschutzerklärung benennen, geben wir keine Daten an Dritte weiter. Wenn Sie Fragen haben, sprechen Sie uns gerne an.</p>
+
+<h2>Inhalt</h2>
+<ul>
+    <li class="first"> <a href="#verantwortlicher">Verantwortlicher</a> </li>
+    <li> <a href="#datenverarbeitung-beim-aufruf-der-webseite">Datenverarbeitung beim Aufruf der Webseite</a> </li>
+    <li> <a href="#cookies-und-zaehlpixel">Cookies und Zählpixel</a> </li>
+    <li> <a href="#kontaktaufnahme">Kontaktaufnahme</a> </li>
+    <li> <a href="#weitere-drittdienste">Weitere Drittdienste</a> </li>
+    <li class="last"> <a href="#rechte-betroffener-personen">Rechte betroffener Personen</a> </li>
+</ul>
+<h2 id="verantwortlicher">Verantwortlicher</h2>
+<p>Verantwortlich für die Datenverarbeitung ist</p>
+<p>Open Knowledge Foundation Deutschland e.V.<br>Singerstraße 109<br>10179&nbsp;Berlin</p>
+<p>Unser Datenschutzbeauftragter ist erreichbar unter:</p>
+
+<p>Open Knowledge Foundation Deutschland e.V.<br/>
+- Datenschutzbeauftragter -<br/>
+Singerstr. 109<br/>
+10179 Berlin<br/>
+Deutschland</p>
+
+<p>datenschutz@okfn.de [<a href="https://okfn.de/okf/datenschutz_okfn_de_pub.asc">OpenPGP</a>]</p>
+
+<p>Unsere externe Datenschutzbeauftragte ist Beata-Konstanze Hubrig von der Rechtsanwaltskanzlei <a href="https://kanzlei-hubrig.de">https://kanzlei-hubrig.de</a></p>
+
+<h2 id="datenverarbeitung-beim-aufruf-der-webseite">Datenverarbeitung beim Aufruf der Webseite</h2>
+<p>Bei jedem Aufruf unserer Webseite überträgt der Browser des Nutzers verschiedene Daten. Für die Dauer des Besuchs der Webseite werden die folgenden Daten verarbeitet und in Logfiles auch über ein Ende der Verbindung hinaus gespeichert:</p>
+<ul>
+    <li>Browsertyp und verwendete -version</li>
+    <li>Betriebssystem</li>
+    <li>Abgerufene Seiten und Dateien</li>
+    <li>Übertragene Datenmenge</li>
+    <li>Datum und Uhrzeit des Abrufs</li>
+    <li>Provider des Nutzers</li>
+    <li>IP-Adresse</li>
+    <li>Referrer URL</li>
+</ul>
+<p>Die Verarbeitung dieser Daten ist erforderlich, um die Webseite an den Nutzer ausliefern zu können und für sein Endgerät zu optimieren. Die Speicherung in Logfiles dient der Verbesserung der Sicherheit unserer Webseite (z.B. Schutz vor DDOS-Angriffen).</p>
+<p>Rechtsgrundlage für die Verarbeitung ist Art.&nbsp;6 Abs.&nbsp;1 UAbs.&nbsp;1 Buchst.&nbsp;) DSGVO. Unser berechtigtes Interesse besteht in der Bereitstellung der Webseite und der Verbesserung der Webseitensicherheit.</p>
+
+<h2 id="cookies-und-zaehlpixel">Cookies und Zählpixel</h2>
+<p>Auf unserer Webseite setzen wir Technologien ein, um das genutzte Endgerät wiederzuerkennen. Es kann sich dabei um Cookies und/oder Zählpixel handeln. </p>
+<p>Das Wiedererkennen eines Endgeräts kann grundsätzlich zu unterschiedlichen Zwecken erfolgen. Es kann notwendig sein, um Funktionen unserer Webseite bereitzustellen, beispielsweise um einen Warenkorb zur Verfügung zu stellen. Darüber hinaus können die genannten Technologien dazu genutzt werden, um das Verhalten von Nutzern auf der Seite nachzuvollziehen, beispielsweise zu Werbezwecken. Welche Technologien wir im Einzelnen nutzen und zu welchen Zwecken, beschreiben wir in dieser Datenschutzerklärung gesondert.</p>
+<p>Für ein besseres Verständnis erläutern wir nachfolgend allgemein, wie Cookies und Zählpixel funktionieren:</p>
+<ul>
+    <li>
+        <p>Cookies sind kleine Textdateien, die bestimmte Informationen beinhalten und auf dem Endgerät des Nutzers gespeichert werden. Zumeist handelt es sich um eine Identifikationsnummer, die einem Endgerät zugewiesen wird (Cookie ID).</p>
+    </li>
+    <li>
+        <p>Bei einem Zählpixel handelt es sich um eine transparente Grafikdatei, die auf einer Seite eingebunden wird und eine Logdateianalyse ermöglicht.</p>
+    </li>
+</ul>
+<p>Cookies können erforderlich sein, damit unsere Webseite ordnungsgemäß funktioniert. Rechtsgrundlage für den Einsatz derartiger Cookies ist Art.&nbsp;6 Abs.&nbsp;1 UAbs.&nbsp;1 Buchst.&nbsp;f) DSGVO. Unser berechtigtes Interesse besteht in der Bereitstellung der Funktionen unserer Webseite.</p>
+<p>Für den Betrieb unserer Webseite nicht erforderliche Cookies setzen wir ein, um unser Angebot nutzerfreundlicher zu machen oder die Nutzung unserer Webseite nachvollziehen zu können. Die Rechtsgrundlage richtet sich hier danach, ob die Einwilligung des Nutzers einzuholen ist oder wir uns auf ein berechtigtes Interesse berufen können. Eine erteilte Einwilligung kann der Nutzer unter anderem durch die Einstellungen in seinem Browser jederzeit widerrufen.</p>
+<p>Der Nutzer kann der Verarbeitung von Daten mithilfe von Cookies durch entsprechende Einstellungen in seinem Browser verhindern und ihr widersprechen. Im Falle des Widerspruchs kann es sein, dass nicht alle Funktionen unserer Webseite zur Verfügung stehen. Über weitere Möglichkeiten des Widerspruchs gegen die Verarbeitung personenbezogener Daten durch Cookies informieren wir in dieser Datenschutzerklärung gesondert. Gegebenenfalls stellen wir Links bereit, mit denen ein Widerspruch erklärt werden kann. Diese sind mit "Opt-Out" beschriftet.</p>
+
+<h2 id="kontaktaufnahme">Kontaktaufnahme</h2>
+<p>Im Falle einer Kontaktaufnahme verarbeiten wir die Angaben des Nutzers, Datum und Uhrzeit zum Zwecke der Bearbeitung der Anfrage einschließlich eventueller Rückfragen.</p>
+<p>Rechtsgrundlage für die Datenverarbeitung ist Art.&nbsp;6 Abs.&nbsp;1 UAbs.&nbsp;1 Buchst.&nbsp;f) DSGVO. Unser berechtigtes Interesse besteht in der Beantwortung der Anfragen unserer Nutzer. Zusätzliche Rechtsgrundlage ist Art.&nbsp;6 Abs.&nbsp;1 UAbs.&nbsp;1 Buchst.&nbsp;b) DSGVO, wenn die Verarbeitung für die Erfüllung eines Vertrags oder zur Durchführung vorvertraglicher Maßnahmen erforderlich ist.</p>
+<p>Die Daten werden gelöscht, sobald die Anfrage einschließlich etwaiger Rückfragen beantwortet ist. Wir überprüfen in regelmäßigen Abständen, mindestens aber alle zwei Jahre, ob im Zusammenhang mit Kontaktaufnahmen angefallene Daten zu löschen sind.</p>
+
+<h2 id="weitere-drittdienste">Weitere Drittdienste</h2>
+<p><strong>Matomo Analytics</strong></p>
+<p>Die Reichweite unserer Webseite messen wir mit Matomo, einem Open-Source-Tool, das wir auf unserem eigenen Server betreiben. </p>
+<p>Dabei wird ggf. ein Cookie auf dem Endgerät des Nutzers gesetzt, über das die Aktivitäten nachverfolgt und beispielsweise wiederkehrende Besuche erkannt werden können. Die IP-Adresse des Nutzers wird automatisch gekürzt, damit ist ein Rückschluss auf einzelne Personen nicht mehr möglich. Ausgewertet werden unter anderem der ungefähre geografische Standort, Endgerät, Bildschirmauflösung, Browser sowie besuchte Seiten einschließlich der Verweildauer.</p>
+<p>Soweit wir eine Einwilligung des Nutzers einholen, erfolgt die Verarbeitung von Daten auf der Rechtsgrundlage des Art.&nbsp;6 Abs.&nbsp;1 UAbs.&nbsp;1 Buchst.&nbsp;a) DSGVO. Im Übrigen beruht sie auf Art.&nbsp;6 Abs.&nbsp;1 UAbs.&nbsp;1 Buchst.&nbsp;f) DSGVO. Unser berechtigtes Interesse besteht in der Optimierung unserer Webseite und der Verbesserung unserer Angebote.</p>
+<p>Durch die Entfernung des folgenden <a href="https://traffic.okfn.de/index.php?module=CoreAdminHome&action=optOut&language=de">Hakens</a> (Opt-Out) können Sie verhindern, dass wir mittels Matomo Ihre Besuche zählen. In diesem Fall wird ein Cookie gesetzt um uns zu signalisieren, dass Sie der Nutzung widersprochen haben.</p>
+
+
+<h2 id="rechte-betroffener-personen">Rechte betroffener Personen</h2>
+<p>Werden personenbezogene Daten des Nutzers verarbeitet, ist er betroffene Person im Sinne der DSGVO. Betroffenen Personen stehen die folgenden Rechte zu:</p>
+<p><strong>Recht auf Auskunft:</strong> Die betroffene Person hat das Recht, eine Bestätigung darüber zu verlangen, ob sie betreffende personenbezogene Daten verarbeitet werden. Werden personenbezogene Daten verarbeitet, so hat die betroffene Person ein Recht auf unentgeltliche Auskunft sowie auf eine Kopie der personenbezogenen Daten, die Gegenstand der Verarbeitung sind.</p>
+<p><strong>Recht auf Berichtigung:</strong> Die betroffene Person hat das Recht, die unverzügliche Berichtigung unrichtiger oder Vervollständigung unvollständiger personenbezogener Daten zu verlangen.</p>
+<p><strong>Recht auf Löschung:</strong> Die betroffene Person hat das Recht, nach Maßgabe der gesetzlichen Bestimmungen eine unverzügliche Löschung sie betreffender personenbezogener Daten zu verlangen.</p>
+<p><strong>Recht auf Einschränkung der Verarbeitung:</strong> Die betroffene Person hat das Recht, nach Maßgabe der gesetzlichen Bestimmungen eine Einschränkung der Verarbeitung sie betreffender personenbezogener Daten zu verlangen.</p>
+<p><strong>Recht auf Datenübertragbarkeit:</strong> Die betroffene Person hat das Recht, die sie betreffenden personenbezogenen Daten in einem strukturierten, gängigen und maschinenlesbaren Format zu erhalten oder eine Übermittlung an einen anderen Verantwortlichen zu verlangen.</p>
+<p><strong>Recht auf Widerspruch:</strong> Die betroffene Person hat das Recht, aus Gründen, die sich aus ihrer besonderen Situation ergeben, jederzeit gegen die Verarbeitung sie betreffender personenbezogener Daten, die aufgrund von Art.&nbsp;6 Abs.&nbsp;1 UAbs.&nbsp;1 Buchst.&nbsp;e) oder f) DSGVO erfolgt, Widerspruch einzulegen; dies gilt auch für ein auf diese Bestimmungen gestütztes Profiling. Werden personenbezogene Daten verarbeitet, um Direktwerbung zu betreiben, so hat die betroffene Person das Recht, jederzeit Widerspruch gegen die Verarbeitung sie betreffender personenbezogener Daten zum Zwecke derartiger Werbung einzulegen; dies gilt auch für das Profiling, soweit es mit solcher Direktwerbung in Verbindung steht.</p>
+<p><strong>Recht auf Widerruf:</strong> Die betroffene Person hat das Recht, ihre erteilte Einwilligung jederzeit zu widerrufen.</p>
+<p><strong>Recht auf Beschwerde:</strong> Die betroffene Person hat das Recht, sich bei einer Aufsichtsbehörde zu beschweren.</p>
+<p><strong>Stand der Datenschutzerklärung:</strong> 27. Juni 2020</p>

--- a/app/views/info/datenschutz.html.erb
+++ b/app/views/info/datenschutz.html.erb
@@ -45,7 +45,7 @@ Deutschland</p>
 
 <h2 id="cookies-und-zaehlpixel">Cookies und Zählpixel</h2>
 <p>Auf unserer Webseite setzen wir Technologien ein, um das genutzte Endgerät wiederzuerkennen. Es kann sich dabei um Cookies und/oder Zählpixel handeln. </p>
-<p>Das Wiedererkennen eines Endgeräts kann grundsätzlich zu unterschiedlichen Zwecken erfolgen. Es kann notwendig sein, um Funktionen unserer Webseite bereitzustellen, beispielsweise um einen Warenkorb zur Verfügung zu stellen. Darüber hinaus können die genannten Technologien dazu genutzt werden, um das Verhalten von Nutzern auf der Seite nachzuvollziehen, beispielsweise zu Werbezwecken. Welche Technologien wir im Einzelnen nutzen und zu welchen Zwecken, beschreiben wir in dieser Datenschutzerklärung gesondert.</p>
+<p>Das Wiedererkennen eines Endgeräts kann grundsätzlich zu unterschiedlichen Zwecken erfolgen. Die genannten Technologien können dazu genutzt werden, um das Verhalten von Nutzern auf der Seite nachzuvollziehen. Welche Technologien wir im Einzelnen nutzen und zu welchen Zwecken, beschreiben wir in dieser Datenschutzerklärung gesondert.</p>
 <p>Für ein besseres Verständnis erläutern wir nachfolgend allgemein, wie Cookies und Zählpixel funktionieren:</p>
 <ul>
     <li>


### PR DESCRIPTION
switched from iubenda to selfhosted html again. 
notes:
* email-search-subscription stuff is gone (no more sendgrid, because it isn't enabled in prod anymore)
* based on template from einfach-abmahnsicher, removed stuff about _mobile identifier_ and especially usage for advertising. we don't do that.